### PR TITLE
fix: surface Invalidate failure only on coupled outage (bump+delete)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,37 @@
+// errors.go
+package cascache
+
+import (
+	"fmt"
+)
+
+type InvalidateError struct {
+	Key     string
+	BumpErr error
+	DelErr  error
+}
+
+func (e *InvalidateError) Error() string {
+	switch {
+	case e.BumpErr != nil && e.DelErr != nil:
+		return fmt.Sprintf("invalidate %q failed: gen bump and delete failed: bump=%v; delete=%v",
+			e.Key, e.BumpErr, e.DelErr)
+	case e.BumpErr != nil:
+		return fmt.Sprintf("invalidate %q: gen bump failed: %v", e.Key, e.BumpErr)
+	case e.DelErr != nil:
+		return fmt.Sprintf("invalidate %q: delete failed: %v", e.Key, e.DelErr)
+	default:
+		return fmt.Sprintf("invalidate %q: unknown error", e.Key)
+	}
+}
+
+func (e *InvalidateError) Unwrap() []error {
+	errs := make([]error, 0, 2)
+	if e.BumpErr != nil {
+		errs = append(errs, e.BumpErr)
+	}
+	if e.DelErr != nil {
+		errs = append(errs, e.DelErr)
+	}
+	return errs
+}


### PR DESCRIPTION
Previously, Invalidate() always returned nil even when both the GenStore bump and Provider delete failed (e.g., full Redis outage). Callers couldn’t detect the failure and stale entries could linger until TTL or a later invalidate. Logs could also be misleading.

Now, Invalidate() returns an *InvalidateError* only when BOTH operations fail.
- bump OK + delete FAIL → no error (reads self-heal via gen mismatch)
- bump FAIL + delete OK → no error (single is gone; bulks may reseed until genstore recovers)
- bump FAIL + delete FAIL → return InvalidateError (likely whole cluster down)

Also:
- Clear failure-mode comments
- Test helpers accept pr.Provider and new edge-case tests

Behavior change (not API-breaking): outage is now visible to callers.