### PR TITLE
CAS117: redis keyreader ttl refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,23 @@ CasCache does more work than a plain cache. Here is what that costs, measured ag
 
 ### Single-key Redis operations
 
-| Operation | Plain Redis | CasCache | Extra cost | Redis round trips |
-| --- | --- | --- | --- | --- |
-| Single read (`Get`) | ~17µs | ~33µs | +16µs | 1 with `redis.New`; 2 on the generic provider path |
-| Snapshot then set (full fill) | ~16µs | ~36µs | +20µs | 3 (miss + snapshot + Lua conditional set) |
-| Single write (`SetIfVersion`) | ~16µs | ~23µs | +7µs | 1 (Lua script, atomic) |
-| Invalidate | ~15µs | ~16µs | +1µs | 1 (Lua script, atomic) |
+| Operation | Plain Redis baseline | CasCache | Extra cost | Slower | Redis round trips |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Single read (`Get`) | ~26.4µs | ~26.9µs | +0.5µs | +1.8% | 1 with `redis.New`; 2 on the generic provider path |
+| Single write (`SetIfVersion`) | ~27.7µs | ~31.9µs | +4.2µs | +15.2% | 1 (Lua script, atomic) |
+| Snapshot then set | ~27.7µs | ~51.3µs | +23.6µs | +60.0% | 2 (snapshot + Lua conditional set) |
+| Invalidate | ~25.7µs | ~26.7µs | +1.1µs | +4.3% | 1 (Lua script, atomic) |
 
-With the Redis backend constructed by `redis.New`, single-key reads fetch the value and authoritative fence together. Generic provider wiring still reads the value and fence separately. Writes and invalidates use Lua scripts to stay atomic in a single round trip. The extra cost per operation is in the low tens of microseconds.
+With the Redis backend constructed by `redis.New`, single-key reads fetch the value and authoritative fence together. Generic provider wiring still reads the value and fence separately. Writes and invalidates use Lua scripts to stay atomic. `SnapshotVersion` plus `SetIfVersion` is the full safe fill-write sequence and is intentionally more expensive than a plain Redis `SET`.
 
 ### Batch operations
 
-| Operation | Extra cost vs plain Redis | Redis round trips |
-| --- | --- | --- |
-| Batch get (32 small keys) | ~4% | 2 (batch blob + `MGET` all fences) |
-| Batch get (32 medium keys) | ~1% | 2 (batch blob + `MGET` all fences) |
+| Operation | Plain Redis baseline | CasCache | Extra cost | Slower | Redis round trips |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Batch get (32 small keys, p4) | ~142.1µs | ~175.5µs | +33.4µs | +23.5% | 2 (batch blob + `MGET` all fences) |
+| Batch get (32 medium keys, p4) | ~278.3µs | ~284.2µs | +5.9µs | +2.1% | 2 (batch blob + `MGET` all fences) |
 
-Batch reads amortize the fence-check cost across all keys with a single `MGET`, so the overhead nearly disappears.
+Batch reads amortize the fence-check cost across all keys with a single `MGET`. The percentage overhead is more visible for small payloads because the fixed validation work is spread over fewer bytes.
 
 ### 50,000 req/s target (mixed workload, 30 seconds)
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ CasCache does more work than a plain cache. Here is what that costs, measured ag
 
 | Operation | Plain Redis | CasCache | Extra cost | Redis round trips |
 | --- | --- | --- | --- | --- |
-| Single read (`Get`) | ~17µs | ~33µs | +16µs | 2 (value + fence check) |
+| Single read (`Get`) | ~17µs | ~33µs | +16µs | 1 with `redis.New`; 2 on the generic provider path |
 | Snapshot then set (full fill) | ~16µs | ~36µs | +20µs | 3 (miss + snapshot + Lua conditional set) |
 | Single write (`SetIfVersion`) | ~16µs | ~23µs | +7µs | 1 (Lua script, atomic) |
 | Invalidate | ~15µs | ~16µs | +1µs | 1 (Lua script, atomic) |
 
-Single-key reads are the most expensive path because every `Get` needs two round trips: one for the value and one for the authoritative fence. Writes and invalidates use Lua scripts to stay atomic in a single round trip. The extra cost per operation is in the low tens of microseconds.
+With the Redis backend constructed by `redis.New`, single-key reads fetch the value and authoritative fence together. Generic provider wiring still reads the value and fence separately. Writes and invalidates use Lua scripts to stay atomic in a single round trip. The extra cost per operation is in the low tens of microseconds.
 
 ### Batch operations
 

--- a/api.go
+++ b/api.go
@@ -114,6 +114,35 @@ type KeyWriter interface {
 	SetIfVersion(ctx context.Context, versionKey version.CacheKey, valueKey string, expected version.Snapshot, payload []byte, ttl time.Duration) (stored bool, err error)
 }
 
+// KeyReadResult is the combined value and version state returned by
+// KeyReader.ReadKey for a single key.
+type KeyReadResult struct {
+	// Raw is the encoded single-entry wire frame held by the provider (the
+	// fence-stamped envelope), not the decoded codec payload. It is only
+	// meaningful when Found is true.
+	Raw []byte
+	// Found reports whether a value entry existed. When false the read is a
+	// miss and Raw, Snapshot, and SnapshotErr are ignored.
+	Found bool
+	// Snapshot is the authoritative version state read alongside the value. It
+	// is consulted only when SnapshotErr is nil.
+	Snapshot version.Snapshot
+	// SnapshotErr carries a version parse or version-state failure that should
+	// fail the read closed (returning a miss) without deleting the value.
+	// Transport or read-command failures must instead be returned as ReadKey's
+	// error so the caller surfaces them as an operation error.
+	SnapshotErr error
+}
+
+// KeyReader is an optional backend-native fast path for single-key reads.
+// Implementations read the encoded value entry and authoritative version state
+// together. Transport/read command failures should be returned as err. Version
+// parse or version-state failures that should fail closed without deleting the
+// value should be returned as SnapshotErr.
+type KeyReader interface {
+	ReadKey(ctx context.Context, versionKey version.CacheKey, valueKey string) (KeyReadResult, error)
+}
+
 // KeyInvalidator is an optional backend-native fast path for single-key
 // invalidation.
 // versionKey identifies the canonical authoritative version state tracked by
@@ -172,6 +201,7 @@ type Options[V any] struct {
 	Disabled       bool          // default false (enabled)
 	ComputeSetCost SetCostFunc   // default 1
 	VersionStore   version.Store // nil => LocalStore (in-process)
+	KeyReader      KeyReader
 	KeyWriter      KeyWriter
 	KeyInvalidator KeyInvalidator
 	DisableBatch   bool // default false => batch enabled

--- a/cache.go
+++ b/cache.go
@@ -16,6 +16,47 @@ import (
 	"github.com/unkn0wn-root/cascache/v3/version"
 )
 
+type batchReadAction uint8
+
+const (
+	batchReadServeAll batchReadAction = iota
+	batchReadServeAcceptedMissRejected
+	batchReadServeAcceptedRefetchRejected
+	batchReadFallbackSingles
+	batchReadMissAll
+)
+
+type batchReadPlan struct {
+	action   batchReadAction
+	reason   BatchRejectReason
+	rejected map[string]struct{}
+}
+
+type batchHit[V any] struct {
+	storageKey string
+	items      map[string]wire.BatchItem
+	values     map[string]V
+}
+
+type batchWriteItem[V any] struct {
+	key string
+	val V
+	obs Version
+}
+
+type batchProjection struct {
+	missing      []string
+	fallbackKeys []string
+}
+
+type batchReadGuardResult struct {
+	reason   BatchRejectReason
+	rejected map[string]struct{}
+}
+
+// singleSeedFunc writes one validated batch member as a single entry.
+type singleSeedFunc func(ctx context.Context, key string, fence version.Fence, payload []byte, ttl time.Duration) error
+
 type cache[V any] struct {
 	ns       string
 	space    keyutil.Keyspace
@@ -35,6 +76,7 @@ type cache[V any] struct {
 	adder          pr.Adder
 	readGuard      ReadGuardFunc[V]
 	batchReadGuard BatchReadGuardFunc[V]
+	keyReader      KeyReader
 	keyWriter      KeyWriter
 	keyInvalidator KeyInvalidator
 
@@ -98,6 +140,7 @@ func newCache[V any](opts Options[V]) (*cache[V], error) {
 		c.hooks.LocalVersionStoreWithBatch()
 	}
 
+	c.keyReader = opts.KeyReader
 	c.keyWriter = opts.KeyWriter
 	c.keyInvalidator = opts.KeyInvalidator
 
@@ -110,211 +153,14 @@ func (c *cache[V]) Enabled() bool { return c.enabled }
 
 // Close shuts down the version store then the provider.
 func (c *cache[V]) Close(ctx context.Context) error {
+	var errs []error
 	if c.versionStore != nil {
-		_ = c.versionStore.Close(ctx)
+		errs = append(errs, c.versionStore.Close(ctx))
 	}
 	if c.provider != nil {
-		return c.provider.Close(ctx)
+		errs = append(errs, c.provider.Close(ctx))
 	}
-	return nil
-}
-
-// Get looks up a single key and returns its value only if the cached entry is
-// still usable.
-//
-// The read passes through three validation gates:
-//
-//  1. Wire: the raw bytes must parse as a valid single-entry frame.
-//  2. Version: the embedded fence must match the current
-//     authoritative fence in the version store.
-//  3. Codec: the payload must decode with the configured codec.
-//
-// Failures in (1), (2), and (3) delete the provider entry and return a miss.
-// If the current authoritative fence cannot be loaded, Get returns a miss without
-// serving or deleting the cached value. Provider read failures are returned
-// as *OpError with OpGet.
-func (c *cache[V]) Get(ctx context.Context, key string) (V, bool, error) {
-	var zero V
-	if !c.enabled {
-		return zero, false, nil
-	}
-
-	sk := c.singleKeys(key)
-	storageKey := sk.Value.String()
-	raw, ok, err := c.provider.Get(ctx, storageKey)
-	if err != nil {
-		return zero, false, opError(OpGet, key, err)
-	}
-	if !ok {
-		return zero, false, nil
-	}
-
-	dfence, payload, err := wire.DecodeSingle(raw)
-	if err != nil {
-		c.selfHealSingle(ctx, storageKey, SelfHealReasonCorrupt)
-		return zero, false, nil
-	}
-
-	snap, err := c.loadSnapshot(ctx, toVersionCacheKey(sk.Cache))
-	if err != nil {
-		return zero, false, nil
-	}
-	if !snap.Exists {
-		c.selfHealSingle(ctx, storageKey, SelfHealReasonVersionMissing)
-		return zero, false, nil
-	}
-	if !dfence.Equal(snap.Fence) {
-		c.selfHealSingle(ctx, storageKey, SelfHealReasonVersionMismatch)
-		return zero, false, nil
-	}
-
-	v, err := c.codec.Decode(payload)
-	if err != nil {
-		c.selfHealSingle(ctx, storageKey, SelfHealReasonValueDecode)
-		return zero, false, nil
-	}
-	if guardReason := c.guardSingleRead(ctx, key, v); guardReason != "" {
-		c.selfHealSingle(ctx, storageKey, guardReason)
-		return zero, false, nil
-	}
-	return v, true, nil
-}
-
-// SnapshotVersion returns the current version for one logical key.
-func (c *cache[V]) SnapshotVersion(ctx context.Context, key string) (Version, error) {
-	snap, err := c.loadSnapshot(ctx, c.versionKey(key))
-	if err != nil {
-		return Version{}, opError(OpSnapshot, key, err)
-	}
-	return versionFromSnapshot(snap), nil
-}
-
-// SetIfVersion writes a value only when the current version still matches the
-// caller's observed version using the cache's configured default TTL.
-func (c *cache[V]) SetIfVersion(
-	ctx context.Context,
-	key string,
-	value V,
-	version Version,
-) (WriteResult, error) {
-	return c.SetIfVersionWithTTL(ctx, key, value, version, c.defaultTTL)
-}
-
-// SetIfVersionWithTTL writes a value only when the current version still
-// matches the caller's observed version. Generic backends perform a final
-// version read immediately before the provider write. When KeyWriter is
-// configured, the backend-native implementation collapses compare and write
-// into one operation.
-func (c *cache[V]) SetIfVersionWithTTL(
-	ctx context.Context,
-	key string,
-	value V,
-	version Version,
-	ttl time.Duration,
-) (WriteResult, error) {
-	if !c.enabled {
-		return WriteResult{Outcome: WriteOutcomeDisabled}, nil
-	}
-	if ttl == 0 {
-		ttl = c.defaultTTL
-	}
-
-	payload, err := c.codec.Encode(value)
-	if err != nil {
-		return WriteResult{}, opError(OpSet, key, err)
-	}
-
-	sk := c.singleKeys(key)
-	ckey := toVersionCacheKey(sk.Cache)
-
-	if c.keyWriter != nil {
-		s, kerr := c.keyWriter.SetIfVersion(
-			ctx,
-			ckey,
-			sk.Value.String(),
-			version.snapshot(),
-			payload,
-			ttl,
-		)
-		if kerr != nil {
-			return WriteResult{}, opError(OpSet, key, kerr)
-		}
-		if !s {
-			return WriteResult{Outcome: WriteOutcomeVersionMismatch}, nil
-		}
-		return WriteResult{Outcome: WriteOutcomeStored}, nil
-	}
-
-	snap, ok, err := c.checkSnapshot(ctx, ckey, version)
-	if err != nil {
-		return WriteResult{Outcome: WriteOutcomeSnapshotError}, opError(OpSnapshot, key, err)
-	}
-	if !ok {
-		return WriteResult{Outcome: WriteOutcomeVersionMismatch}, nil
-	}
-
-	sw, err := c.buildSingleWrite(sk, snap.Fence, payload)
-	if err != nil {
-		return WriteResult{}, opError(OpSet, key, err)
-	}
-
-	s, err := c.setSingle(ctx, sw, ttl)
-	if err != nil {
-		return WriteResult{}, opError(OpSet, key, err)
-	}
-	if !s {
-		return WriteResult{Outcome: WriteOutcomeProviderRejected}, nil
-	}
-	return WriteResult{Outcome: WriteOutcomeStored}, nil
-}
-
-// Invalidate marks a key as stale so that future readers will not serve it.
-// Backends perform two operations in a specific order:
-//
-//  1. Advance the authoritative fence in the version store, which makes every
-//     existing cached entry for this key stale because its embedded fence
-//     will no longer match.
-//
-//  2. Delete the single entry from the provider as a courtesy so the stale
-//     bytes do not linger and waste memory.
-//
-// The order matters. Advancing first ensures that even if the delete fails,
-// readers will see the fence mismatch and self-heal on the next read.
-// If we deleted first and the advance then failed, a batch entry could reseed
-// the single with stale data and the fence check would still pass.
-func (c *cache[V]) Invalidate(ctx context.Context, key string) error {
-	if !c.enabled {
-		return nil
-	}
-
-	sk := c.singleKeys(key)
-	if c.keyInvalidator != nil {
-		if err := c.keyInvalidator.Invalidate(
-			ctx,
-			toVersionCacheKey(sk.Cache),
-			sk.Value.String(),
-		); err != nil {
-			c.hooks.InvalidateOutage(key, err, nil)
-			return &InvalidateError{
-				Key:        key,
-				AdvanceErr: opError(OpInvalidate, key, err),
-			}
-		}
-		return nil
-	}
-
-	_, bErr := c.advanceVersion(ctx, toVersionCacheKey(sk.Cache))
-	delErr := c.provider.Del(ctx, sk.Value.String())
-
-	if bErr != nil {
-		c.hooks.InvalidateOutage(key, bErr, delErr)
-		return &InvalidateError{
-			Key:        key,
-			AdvanceErr: opError(OpInvalidate, key, bErr),
-			DelErr:     opError(OpInvalidate, key, delErr),
-		}
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // GetMany retrieves multiple keys in one call, trying the most efficient
@@ -644,37 +490,17 @@ func (c *cache[V]) advanceVersion(ctx context.Context, cacheKey version.CacheKey
 	return s, nil
 }
 
-type batchHit[V any] struct {
-	storageKey string
-	items      map[string]wire.BatchItem
-	values     map[string]V
-}
-
-type batchWriteItem[V any] struct {
-	key string
-	val V
-	obs Version
-}
-
-type batchReadAction uint8
-
-const (
-	batchReadServeAll batchReadAction = iota
-	batchReadServeAcceptedMissRejected
-	batchReadServeAcceptedRefetchRejected
-	batchReadFallbackSingles
-	batchReadMissAll
-)
-
-type batchReadPlan struct {
-	action   batchReadAction
-	reason   BatchRejectReason
-	rejected map[string]struct{}
-}
-
-type batchProjection struct {
-	missing      []string
-	fallbackKeys []string
+func (c *cache[V]) refreshVersion(ctx context.Context, cacheKey version.CacheKey) (bool, error) {
+	refresher, ok := c.versionStore.(version.Refresher)
+	if !ok {
+		return true, nil
+	}
+	refreshed, err := refresher.Refresh(ctx, cacheKey)
+	if err != nil {
+		c.hooks.VersionSnapshotError(1, err)
+		return false, err
+	}
+	return refreshed, nil
 }
 
 // batchRejectReason reports whether a stored batch entry can serve the requested
@@ -943,11 +769,6 @@ func (c *cache[V]) batchKeySorted(sortedKeys []string) (keyutil.ValueKey, error)
 	return c.space.BatchValueSorted(sortedKeys)
 }
 
-type batchReadGuardResult struct {
-	reason   BatchRejectReason
-	rejected map[string]struct{}
-}
-
 func (r batchReadGuardResult) allowed() bool { return r.reason == "" }
 
 // guardSingleRead applies the configured single-key read guard and translates
@@ -1037,14 +858,16 @@ func (c *cache[V]) decodeBatch(requested []string, items map[string]wire.BatchIt
 	return bk, nil
 }
 
-// seedBatch materializes validated batch members as single key entries.
-// It assumes the caller already established that each member fence is safe to
-// serve, so it does not re-check the version store.
-func (c *cache[V]) seedBatch(
+// seedFromItems materializes the requested batch members as single entries via
+// write, wrapping any per-key failure as an OpError tagged with op. Requested
+// keys absent from items are skipped.
+func (c *cache[V]) seedFromItems(
 	ctx context.Context,
 	requested []string,
 	items map[string]wire.BatchItem,
 	ttl time.Duration,
+	op Op,
+	write singleSeedFunc,
 ) error {
 	if len(requested) == 0 || len(items) == 0 {
 		return nil
@@ -1056,11 +879,23 @@ func (c *cache[V]) seedBatch(
 		if !ok {
 			continue
 		}
-		if err := c.writeSingle(ctx, k, it.Fence, it.Payload, ttl); err != nil {
-			errs = append(errs, &OpError{Op: OpSet, Key: k, Err: err})
+		if err := write(ctx, k, it.Fence, it.Payload, ttl); err != nil {
+			errs = append(errs, &OpError{Op: op, Key: k, Err: err})
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// seedBatch materializes validated batch members as single key entries.
+// It assumes the caller already established that each member fence is safe to
+// serve, so it does not re-check the version store.
+func (c *cache[V]) seedBatch(
+	ctx context.Context,
+	requested []string,
+	items map[string]wire.BatchItem,
+	ttl time.Duration,
+) error {
+	return c.seedFromItems(ctx, requested, items, ttl, OpSet, c.writeSingle)
 }
 
 // seedAfterBatch materializes singles after a successful batch
@@ -1092,21 +927,7 @@ func (c *cache[V]) seedBatchIfMissing(
 	items map[string]wire.BatchItem,
 	ttl time.Duration,
 ) error {
-	if len(requested) == 0 || len(items) == 0 {
-		return nil
-	}
-
-	var errs []error
-	for _, k := range requested {
-		it, ok := items[k]
-		if !ok {
-			continue
-		}
-		if err := c.addSingle(ctx, k, it.Fence, it.Payload, ttl); err != nil {
-			errs = append(errs, &OpError{Op: OpAdd, Key: k, Err: err})
-		}
-	}
-	return errors.Join(errs...)
+	return c.seedFromItems(ctx, requested, items, ttl, OpAdd, c.addSingle)
 }
 
 func (c *cache[V]) seedFromBatch(
@@ -1125,88 +946,6 @@ func (c *cache[V]) seedFromBatch(
 		}
 	}
 	return errors.Join(errs...)
-}
-
-type singleWrite struct {
-	storageKey string
-	wire       []byte
-	cost       int64
-}
-
-// buildSingleWrite builds the provider payload and admission metadata for a
-// single entry write from an already encoded value payload.
-func (c *cache[V]) buildSingleWrite(
-	sk keyutil.Single,
-	fence version.Fence,
-	payload []byte,
-) (singleWrite, error) {
-	wireb, err := wire.EncodeSingle(fence, payload)
-	if err != nil {
-		return singleWrite{}, err
-	}
-
-	sKey := sk.Value.String()
-	return singleWrite{
-		storageKey: sKey,
-		wire:       wireb,
-		cost:       c.computeSetCost(sKey, wireb, false, 1),
-	}, nil
-}
-
-// selfHealSingle deletes one unusable single entry and emits the matching
-// hook reason. Read paths call this after conservative validation failures.
-func (c *cache[V]) selfHealSingle(ctx context.Context, storageKey string, reason SelfHealReason) {
-	_ = c.provider.Del(ctx, storageKey)
-	c.hooks.SelfHealSingle(storageKey, reason)
-}
-
-// setSingle executes a prepared single-entry provider Set and reports
-// admission rejection through hooks without treating it as an error.
-func (c *cache[V]) setSingle(ctx context.Context, sw singleWrite, ttl time.Duration) (bool, error) {
-	ok, err := c.provider.Set(ctx, sw.storageKey, sw.wire, sw.cost, ttl)
-	if err != nil {
-		return false, err
-	}
-	if !ok {
-		c.hooks.ProviderSetRejected(sw.storageKey, false)
-	}
-	return ok, nil
-}
-
-// writeSingle encodes one single entry frame from an already validated batch
-// member and stores it through the normal provider Set path.
-func (c *cache[V]) writeSingle(
-	ctx context.Context,
-	key string,
-	fence version.Fence,
-	payload []byte,
-	ttl time.Duration,
-) error {
-	sk := c.singleKeys(key)
-	sw, err := c.buildSingleWrite(sk, fence, payload)
-	if err != nil {
-		return err
-	}
-	_, err = c.setSingle(ctx, sw, ttl)
-	return err
-}
-
-// addSingle encodes one single-entry frame from an already validated batch
-// member and inserts it only if the provider reports the key as missing.
-func (c *cache[V]) addSingle(
-	ctx context.Context,
-	key string,
-	fence version.Fence,
-	payload []byte,
-	ttl time.Duration,
-) error {
-	sk := c.singleKeys(key)
-	sw, err := c.buildSingleWrite(sk, fence, payload)
-	if err != nil {
-		return err
-	}
-	_, err = c.adder.Add(ctx, sw.storageKey, sw.wire, sw.cost, ttl)
-	return err
 }
 
 // seedSingles writes each item as an individual single entry via SetIfVersion.

--- a/cache_test.go
+++ b/cache_test.go
@@ -367,6 +367,79 @@ type recordingKeyAdapter struct {
 
 var _ KeyMutator = (*recordingKeyAdapter)(nil)
 
+type recordingKeyReader struct {
+	result         KeyReadResult
+	err            error
+	calls          int
+	lastVersionKey version.CacheKey
+	lastValueKey   string
+}
+
+var _ KeyReader = (*recordingKeyReader)(nil)
+
+func (r *recordingKeyReader) ReadKey(
+	_ context.Context,
+	versionKey version.CacheKey,
+	valueKey string,
+) (KeyReadResult, error) {
+	r.calls++
+	r.lastVersionKey = versionKey
+	r.lastValueKey = valueKey
+	return r.result, r.err
+}
+
+type recordingHooks struct {
+	NopHooks
+	versionSnapshotErrors int
+	selfHeals             []SelfHealReason
+}
+
+func (h *recordingHooks) VersionSnapshotError(int, error) {
+	h.versionSnapshotErrors++
+}
+
+func (h *recordingHooks) SelfHealSingle(_ string, r SelfHealReason) {
+	h.selfHeals = append(h.selfHeals, r)
+}
+
+type closeErrProvider struct {
+	*memProvider
+	err error
+}
+
+var _ pr.Provider = (*closeErrProvider)(nil)
+
+func (p *closeErrProvider) Close(context.Context) error {
+	return p.err
+}
+
+type closeErrVersionStore struct {
+	version.Store
+	err error
+}
+
+var _ version.Store = (*closeErrVersionStore)(nil)
+
+func (s *closeErrVersionStore) Close(context.Context) error {
+	return s.err
+}
+
+type refreshingVersionStore struct {
+	version.Store
+	refreshCalls int
+	refreshed    bool
+	refreshErr   error
+	lastRefresh  version.CacheKey
+}
+
+var _ version.Refresher = (*refreshingVersionStore)(nil)
+
+func (s *refreshingVersionStore) Refresh(_ context.Context, cacheKey version.CacheKey) (bool, error) {
+	s.refreshCalls++
+	s.lastRefresh = cacheKey
+	return s.refreshed, s.refreshErr
+}
+
 func (s *recordingKeyAdapter) SetIfVersion(
 	_ context.Context,
 	versionKey version.CacheKey,
@@ -517,6 +590,20 @@ func mutateFence(f version.Fence, mutate func([]byte)) version.Fence {
 	return mutated
 }
 
+func mustEncodeUserSingle(t *testing.T, f version.Fence, value user) []byte {
+	t.Helper()
+
+	payload, err := (c.JSON[user]{}).Encode(value)
+	if err != nil {
+		t.Fatalf("Encode user: %v", err)
+	}
+	raw, err := wire.EncodeSingle(f, payload)
+	if err != nil {
+		t.Fatalf("EncodeSingle: %v", err)
+	}
+	return raw
+}
+
 func closeTest(t *testing.T, ctx context.Context, c interface{ Close(context.Context) error }) {
 	t.Helper()
 	if err := c.Close(ctx); err != nil {
@@ -540,7 +627,7 @@ func assertExpiryBefore(
 	}
 }
 
-func mustImpl(t *testing.T, c interface{}) *cache[user] {
+func mustImpl(t *testing.T, c any) *cache[user] {
 	t.Helper()
 	switch cc := c.(type) {
 	case *cache[user]:
@@ -653,6 +740,143 @@ func TestSingleCASFlow(t *testing.T) {
 	}
 	if got, ok, err := cc.Get(ctx, k); err != nil || !ok || got != v {
 		t.Fatalf("Get after fresh set: ok=%v err=%v got=%v", ok, err, got)
+	}
+}
+
+func TestGetKeyReaderHit(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("provider get should not be called")
+	mp := &getErrProvider{memProvider: newMemProvider(), err: sentinel}
+	fence := testFence(1)
+	want := user{ID: "1", Name: "Ada"}
+	reader := &recordingKeyReader{
+		result: KeyReadResult{
+			Raw:      mustEncodeUserSingle(t, fence, want),
+			Found:    true,
+			Snapshot: version.Snapshot{Fence: fence, Exists: true},
+		},
+	}
+	vs := &countingVersionStore{inner: version.NewLocal()}
+
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.KeyReader = reader
+		o.VersionStore = vs
+	})
+	defer closeTest(t, ctx, cc)
+
+	got, ok, err := cc.Get(ctx, "u:1")
+	if err != nil || !ok || got != want {
+		t.Fatalf("Get via KeyReader: got=%+v ok=%v err=%v", got, ok, err)
+	}
+	if reader.calls != 1 {
+		t.Fatalf("KeyReader calls=%d, want 1", reader.calls)
+	}
+	if vs.snapshotCalls != 0 || vs.snapshotManyCalls != 0 {
+		t.Fatalf(
+			"version store should not be read on KeyReader hit, snapshot=%d many=%d",
+			vs.snapshotCalls,
+			vs.snapshotManyCalls,
+		)
+	}
+}
+
+func TestGetKeyReaderSnapshotErr(t *testing.T) {
+	ctx := context.Background()
+	mp := newMemProvider()
+	hooks := &recordingHooks{}
+	fence := testFence(2)
+	reader := &recordingKeyReader{
+		result: KeyReadResult{
+			Raw:         mustEncodeUserSingle(t, fence, user{ID: "1", Name: "Ada"}),
+			Found:       true,
+			SnapshotErr: errors.New("bad version state"),
+		},
+	}
+
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.KeyReader = reader
+		o.Hooks = hooks
+	})
+	defer closeTest(t, ctx, cc)
+
+	impl := mustImpl(t, cc)
+	sk := impl.singleKeys("u:1")
+	mp.m[sk.Value.String()] = memEntry{v: []byte("keep")}
+
+	got, ok, err := cc.Get(ctx, "u:1")
+	if err != nil || ok {
+		t.Fatalf("Get should fail closed to miss, got=%+v ok=%v err=%v", got, ok, err)
+	}
+	if hooks.versionSnapshotErrors != 1 {
+		t.Fatalf("VersionSnapshotError hooks=%d, want 1", hooks.versionSnapshotErrors)
+	}
+	if _, found := mp.m[sk.Value.String()]; !found {
+		t.Fatalf("snapshot error should not delete provider entry")
+	}
+	if len(hooks.selfHeals) != 0 {
+		t.Fatalf("snapshot error should not self-heal, got %v", hooks.selfHeals)
+	}
+}
+
+func TestGetKeyReaderCorrupt(t *testing.T) {
+	ctx := context.Background()
+	mp := newMemProvider()
+	hooks := &recordingHooks{}
+	reader := &recordingKeyReader{
+		result: KeyReadResult{
+			Raw:   []byte("not a cascache wire frame"),
+			Found: true,
+		},
+	}
+
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.KeyReader = reader
+		o.Hooks = hooks
+	})
+	defer closeTest(t, ctx, cc)
+
+	impl := mustImpl(t, cc)
+	sk := impl.singleKeys("u:1")
+	mp.m[sk.Value.String()] = memEntry{v: []byte("delete me")}
+
+	got, ok, err := cc.Get(ctx, "u:1")
+	if err != nil || ok {
+		t.Fatalf("Get should miss corrupt KeyReader value, got=%+v ok=%v err=%v", got, ok, err)
+	}
+	if _, found := mp.m[sk.Value.String()]; found {
+		t.Fatalf("corrupt KeyReader value should delete provider entry")
+	}
+	if len(hooks.selfHeals) != 1 || hooks.selfHeals[0] != SelfHealReasonCorrupt {
+		t.Fatalf("self-heal reasons=%v, want [%s]", hooks.selfHeals, SelfHealReasonCorrupt)
+	}
+}
+
+func TestGetCorruptBeforeSnapshot(t *testing.T) {
+	ctx := context.Background()
+	mp := newMemProvider()
+	hooks := &recordingHooks{}
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.Hooks = hooks
+		o.VersionStore = &failingVersionStore{snapshotErr: errors.New("snapshot failed")}
+	})
+	defer closeTest(t, ctx, cc)
+
+	impl := mustImpl(t, cc)
+	sk := impl.singleKeys("u:1")
+	mp.m[sk.Value.String()] = memEntry{v: []byte("not a cascache wire frame")}
+
+	got, ok, err := cc.Get(ctx, "u:1")
+	if err != nil || ok {
+		t.Fatalf("Get should miss corrupt generic value, got=%+v ok=%v err=%v", got, ok, err)
+	}
+	if _, found := mp.m[sk.Value.String()]; found {
+		t.Fatalf("corrupt generic value should be deleted before snapshot read")
+	}
+	if len(hooks.selfHeals) != 1 || hooks.selfHeals[0] != SelfHealReasonCorrupt {
+		t.Fatalf("self-heal reasons=%v, want [%s]", hooks.selfHeals, SelfHealReasonCorrupt)
+	}
+	if hooks.versionSnapshotErrors != 0 {
+		t.Fatalf("snapshot should not be loaded after corrupt wire, hooks=%d", hooks.versionSnapshotErrors)
 	}
 }
 
@@ -811,6 +1035,106 @@ func TestSetIfVersionSnapshotErrorReturnsErrorAndSkipsWrite(t *testing.T) {
 	impl := mustImpl(t, cc)
 	if _, ok, _ := mp.Get(ctx, impl.singleKeys("u:1").Value.String()); ok {
 		t.Fatalf("SetIfVersion should skip writes when snapshot fails")
+	}
+}
+
+func TestSetRefreshesVersionTTL(t *testing.T) {
+	ctx := context.Background()
+	mp := newMemProvider()
+	vs := &refreshingVersionStore{Store: version.NewLocal(), refreshed: true}
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.VersionStore = vs
+	})
+	defer closeTest(t, ctx, cc)
+
+	key := "u:ttl"
+	first := user{ID: "ttl", Name: "first"}
+	result, err := cc.SetIfVersion(ctx, key, first, Version{})
+	if err != nil || !result.Stored() {
+		t.Fatalf("first SetIfVersion: result=%+v err=%v", result, err)
+	}
+	if vs.refreshCalls != 0 {
+		t.Fatalf("missing-version create should not need refresh, got %d calls", vs.refreshCalls)
+	}
+
+	obs := mustSnapshotVersion(t, ctx, cc, key)
+	second := user{ID: "ttl", Name: "second"}
+	result, err = cc.SetIfVersion(ctx, key, second, obs)
+	if err != nil || !result.Stored() {
+		t.Fatalf("second SetIfVersion: result=%+v err=%v", result, err)
+	}
+	if vs.refreshCalls != 1 {
+		t.Fatalf("existing-version write should refresh once, got %d", vs.refreshCalls)
+	}
+
+	impl := mustImpl(t, cc)
+	if vs.lastRefresh != impl.versionKey(key) {
+		t.Fatalf("Refresh key=%q, want %q", vs.lastRefresh, impl.versionKey(key))
+	}
+}
+
+func TestSetRefreshError(t *testing.T) {
+	ctx := context.Background()
+	mp := newMemProvider()
+	vs := &refreshingVersionStore{Store: version.NewLocal(), refreshed: true}
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.VersionStore = vs
+	})
+	defer closeTest(t, ctx, cc)
+
+	key := "u:ttl-error"
+	first := user{ID: "ttl-error", Name: "first"}
+	if result, err := cc.SetIfVersion(ctx, key, first, Version{}); err != nil || !result.Stored() {
+		t.Fatalf("first SetIfVersion: result=%+v err=%v", result, err)
+	}
+
+	vs.refreshErr = errors.New("refresh failed")
+	obs := mustSnapshotVersion(t, ctx, cc, key)
+	result, err := cc.SetIfVersion(ctx, key, user{ID: "ttl-error", Name: "second"}, obs)
+	if err == nil {
+		t.Fatalf("SetIfVersion should return refresh error")
+	}
+	if !errors.Is(err, vs.refreshErr) {
+		t.Fatalf("SetIfVersion error=%v, want %v", err, vs.refreshErr)
+	}
+	if result.Outcome != WriteOutcomeSnapshotError {
+		t.Fatalf("SetIfVersion outcome=%q, want %q", result.Outcome, WriteOutcomeSnapshotError)
+	}
+
+	got, ok, err := cc.Get(ctx, key)
+	if err != nil || !ok || got != first {
+		t.Fatalf("refresh failure should skip provider write, got=%+v ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestSetRefreshMissing(t *testing.T) {
+	ctx := context.Background()
+	mp := newMemProvider()
+	vs := &refreshingVersionStore{Store: version.NewLocal(), refreshed: true}
+	cc := newTestCache(t, "user", mp, func(o *Options[user]) {
+		o.VersionStore = vs
+	})
+	defer closeTest(t, ctx, cc)
+
+	key := "u:ttl-missing"
+	first := user{ID: "ttl-missing", Name: "first"}
+	if result, err := cc.SetIfVersion(ctx, key, first, Version{}); err != nil || !result.Stored() {
+		t.Fatalf("first SetIfVersion: result=%+v err=%v", result, err)
+	}
+
+	vs.refreshed = false
+	obs := mustSnapshotVersion(t, ctx, cc, key)
+	result, err := cc.SetIfVersion(ctx, key, user{ID: "ttl-missing", Name: "second"}, obs)
+	if err != nil {
+		t.Fatalf("SetIfVersion should not error on refresh-missing mismatch: %v", err)
+	}
+	if result.Outcome != WriteOutcomeVersionMismatch {
+		t.Fatalf("SetIfVersion outcome=%q, want %q", result.Outcome, WriteOutcomeVersionMismatch)
+	}
+
+	got, ok, err := cc.Get(ctx, key)
+	if err != nil || !ok || got != first {
+		t.Fatalf("refresh missing should skip provider write, got=%+v ok=%v err=%v", got, ok, err)
 	}
 }
 
@@ -1096,6 +1420,30 @@ func TestSelfHealOnCorrupt(t *testing.T) {
 	}
 	if _, ok, _ := mp.Get(ctx, sk.Value.String()); ok {
 		t.Fatalf("stale entry was not deleted by self-heal")
+	}
+}
+
+func TestCloseReturnsAllErrors(t *testing.T) {
+	ctx := context.Background()
+	versionErr := errors.New("version close failed")
+	providerErr := errors.New("provider close failed")
+
+	cc := newTestCache(t, "user", &closeErrProvider{
+		memProvider: newMemProvider(),
+		err:         providerErr,
+	}, func(o *Options[user]) {
+		o.VersionStore = &closeErrVersionStore{
+			Store: version.NewLocal(),
+			err:   versionErr,
+		}
+	})
+
+	err := cc.Close(ctx)
+	if !errors.Is(err, versionErr) {
+		t.Fatalf("Close error should include version error, got %v", err)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("Close error should include provider error, got %v", err)
 	}
 }
 

--- a/codec/raw.go
+++ b/codec/raw.go
@@ -1,12 +1,24 @@
 package codec
 
-// Bytes is an identity codec for []byte values. Encode/Decode return the
-// input unchanged. Useful when your value type is already a raw byte slice
-// and you only need cascache's wire framing and validation.
+import "bytes"
+
+// Bytes is an identity codec for []byte values. Encode/Decode return the input
+// unchanged, so callers must treat byte slices as immutable after handing them
+// to the cache and after receiving them from the cache.
 type Bytes struct{}
 
 func (Bytes) Encode(b []byte) ([]byte, error) { return b, nil }
 func (Bytes) Decode(b []byte) ([]byte, error) { return b, nil }
+
+// BytesClone is a defensive []byte codec. Encode and Decode return copies via
+// bytes.Clone, so caller mutations cannot alias codec output and cached bytes
+// cannot be mutated through a returned slice. Like Bytes, nil clones to nil and
+// an empty slice clones to empty; unlike Bytes, the result never shares backing
+// storage with its input.
+type BytesClone struct{}
+
+func (BytesClone) Encode(b []byte) ([]byte, error) { return bytes.Clone(b), nil }
+func (BytesClone) Decode(b []byte) ([]byte, error) { return bytes.Clone(b), nil }
 
 // String is a trivial codec for Go string values. Encode converts to []byte,
 // and Decode converts back to string. By convention this assumes UTF-8 and

--- a/codec/safety_test.go
+++ b/codec/safety_test.go
@@ -1,6 +1,7 @@
 package codec
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -50,5 +51,29 @@ func TestProtobufNilCtorResultReturnsError(t *testing.T) {
 
 	if _, err := c.Decode(nil); !errors.Is(err, ErrUninitializedProtobuf) {
 		t.Fatalf("Decode error mismatch: %v", err)
+	}
+}
+
+func TestBytesCloneCopies(t *testing.T) {
+	t.Parallel()
+
+	c := BytesClone{}
+	src := []byte("abc")
+	enc, err := c.Encode(src)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	src[0] = 'z'
+	if !bytes.Equal(enc, []byte("abc")) {
+		t.Fatalf("Encode returned aliased bytes: %q", enc)
+	}
+
+	dec, err := c.Decode(enc)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	enc[0] = 'y'
+	if !bytes.Equal(dec, []byte("abc")) {
+		t.Fatalf("Decode returned aliased bytes: %q", dec)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -14,6 +14,8 @@
 //     single-key compare-and-write and invalidate. KeyMutator is the
 //     alias for implementations that provide both. See the redis
 //     subpackage for the built-in Redis implementation.
+//   - KeyReader: optional backend-native fast path for reading a single value
+//     and its authoritative version state together.
 //
 // Keys:
 //

--- a/redis/doc.go
+++ b/redis/doc.go
@@ -1,6 +1,8 @@
 // Package redis contains the Redis backend for cascache.
 //
 // Most callers should use New.
+// New wires the Redis value provider, version store, single-key read fast path,
+// and single-key mutation scripts from one shared client.
 //
 // The lower-level constructors exist for custom topologies:
 //   - NewVersionStore when values stay outside Redis but version state must be shared.

--- a/redis/mutator.go
+++ b/redis/mutator.go
@@ -22,7 +22,10 @@ type KeyMutator struct {
 	versionTTL time.Duration
 }
 
-var _ cascache.KeyMutator = (*KeyMutator)(nil)
+var (
+	_ cascache.KeyMutator = (*KeyMutator)(nil)
+	_ cascache.KeyReader  = (*KeyMutator)(nil)
+)
 
 var setIfVersionScript = goredis.NewScript(`
 local current = redis.call("GET", KEYS[1])
@@ -39,6 +42,11 @@ if current then
 	end
 	if current ~= expected_fence then
 		return 0
+	end
+	if version_ttl_ms and version_ttl_ms > 0 then
+		redis.call("PEXPIRE", KEYS[1], version_ttl_ms)
+	else
+		redis.call("PERSIST", KEYS[1])
 	end
 else
 	if not expect_missing then
@@ -151,6 +159,39 @@ func (s *KeyMutator) SetIfVersion(
 	return r == 1, nil
 }
 
+func (s *KeyMutator) ReadKey(
+	ctx context.Context,
+	versionKey version.CacheKey,
+	valueKey string,
+) (cascache.KeyReadResult, error) {
+	if s == nil || s.client == nil {
+		return cascache.KeyReadResult{}, ErrNilClient
+	}
+
+	vals, err := s.client.MGet(ctx, valueKey, versionStorageKey(versionKey)).Result()
+	if err != nil {
+		return cascache.KeyReadResult{}, err
+	}
+	if len(vals) != 2 {
+		return cascache.KeyReadResult{}, errors.New("cascache/redis: unexpected MGET result length")
+	}
+
+	var out cascache.KeyReadResult
+	if vals[0] != nil {
+		raw, err := redisBytes(vals[0])
+		if err != nil {
+			return cascache.KeyReadResult{}, err
+		}
+		out.Raw = raw
+		out.Found = true
+	}
+
+	snap, snapErr := parseSnapshotValue(versionKey, vals[1])
+	out.Snapshot = snap
+	out.SnapshotErr = snapErr
+	return out, nil
+}
+
 func (s *KeyMutator) Invalidate(
 	ctx context.Context,
 	versionKey version.CacheKey,
@@ -188,4 +229,15 @@ func ttlMillis(ttl time.Duration) int64 {
 		return 1
 	}
 	return ms
+}
+
+func redisBytes(raw any) ([]byte, error) {
+	switch v := raw.(type) {
+	case string:
+		return []byte(v), nil
+	case []byte:
+		return v, nil
+	default:
+		return nil, errors.New("cascache/redis: unsupported redis value type")
+	}
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -77,6 +77,7 @@ func New[V any](opts Options[V]) (cascache.CAS[V], error) {
 		Disabled:       opts.Disabled,
 		ComputeSetCost: opts.ComputeSetCost,
 		VersionStore:   ver,
+		KeyReader:      mutator,
 		KeyWriter:      mutator,
 		KeyInvalidator: mutator,
 		DisableBatch:   opts.DisableBatch,

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -58,6 +59,49 @@ func (c *snapshotCmdClient) MGet(ctx context.Context, keys ...string) *goredis.S
 	return goredis.NewSliceResult(nil, nil)
 }
 
+type scriptCmdClient struct {
+	goredis.UniversalClient
+	evalShaCalls int
+	evalCalls    int
+	script       string
+	keys         []string
+	args         []any
+	result       int64
+	resultSet    bool
+}
+
+type fakeRedisError string
+
+func (e fakeRedisError) Error() string { return string(e) }
+func (fakeRedisError) RedisError()     {}
+
+func (c *scriptCmdClient) EvalSha(
+	context.Context,
+	string,
+	[]string,
+	...any,
+) *goredis.Cmd {
+	c.evalShaCalls++
+	return goredis.NewCmdResult(nil, fakeRedisError("NOSCRIPT no matching script"))
+}
+
+func (c *scriptCmdClient) Eval(
+	_ context.Context,
+	script string,
+	keys []string,
+	args ...any,
+) *goredis.Cmd {
+	c.evalCalls++
+	c.script = script
+	c.keys = append([]string(nil), keys...)
+	c.args = append([]any(nil), args...)
+	result := int64(1)
+	if c.resultSet {
+		result = c.result
+	}
+	return goredis.NewCmdResult(result, nil)
+}
+
 func TestNewKeyMutatorNilClient(t *testing.T) {
 	t.Parallel()
 
@@ -109,6 +153,152 @@ func TestNewVersionStoreWithOptionsStoresVersionTTL(t *testing.T) {
 	}
 	if store.versionTTL != 90*time.Second {
 		t.Fatalf("versionTTL = %v, want %v", store.versionTTL, 90*time.Second)
+	}
+}
+
+func TestVersionStoreRefreshPExpire(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptCmdClient{}
+	store, err := NewVersionStoreWithOptions(VersionStoreOptions{
+		Client:     client,
+		VersionTTL: 90 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewVersionStoreWithOptions: %v", err)
+	}
+
+	key := version.NewCacheKey("k")
+	refreshed, err := store.Refresh(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if !refreshed {
+		t.Fatalf("Refresh refreshed=false, want true")
+	}
+	if len(client.keys) != 1 || client.keys[0] != versionStorageKey(key) {
+		t.Fatalf("Refresh keys=%v, want [%q]", client.keys, versionStorageKey(key))
+	}
+	if len(client.args) != 1 || client.args[0] != int64((90*time.Second).Milliseconds()) {
+		t.Fatalf("Refresh args=%v, want ttl ms", client.args)
+	}
+	if !strings.Contains(client.script, "GET") ||
+		!strings.Contains(client.script, "PEXPIRE") ||
+		!strings.Contains(client.script, "PERSIST") {
+		t.Fatalf("refresh script should check existence and refresh/persist:\n%s", client.script)
+	}
+}
+
+func TestVersionStoreRefreshPersist(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptCmdClient{}
+	store, err := NewVersionStoreWithOptions(VersionStoreOptions{Client: client})
+	if err != nil {
+		t.Fatalf("NewVersionStoreWithOptions: %v", err)
+	}
+
+	key := version.NewCacheKey("k")
+	refreshed, err := store.Refresh(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if !refreshed {
+		t.Fatalf("Refresh refreshed=false, want true")
+	}
+	if len(client.args) != 1 || client.args[0] != int64(0) {
+		t.Fatalf("Refresh args=%v, want zero ttl", client.args)
+	}
+}
+
+func TestVersionStoreRefreshMissing(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptCmdClient{resultSet: true}
+	store, err := NewVersionStoreWithOptions(VersionStoreOptions{Client: client})
+	if err != nil {
+		t.Fatalf("NewVersionStoreWithOptions: %v", err)
+	}
+
+	refreshed, err := store.Refresh(context.Background(), version.NewCacheKey("k"))
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if refreshed {
+		t.Fatalf("Refresh refreshed=true, want false for missing version state")
+	}
+}
+
+func TestKeyMutatorSetVersionTTL(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptCmdClient{}
+	mutator, err := NewKeyMutatorWithOptions(KeyMutatorOptions{
+		Client:     client,
+		VersionTTL: 1500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewKeyMutatorWithOptions: %v", err)
+	}
+	fence, err := version.NewFence()
+	if err != nil {
+		t.Fatalf("NewFence: %v", err)
+	}
+
+	stored, err := mutator.SetIfVersion(
+		context.Background(),
+		version.NewCacheKey("k"),
+		"value-key",
+		version.Snapshot{Fence: fence, Exists: true},
+		[]byte("payload"),
+		time.Minute,
+	)
+	if err != nil || !stored {
+		t.Fatalf("SetIfVersion: stored=%v err=%v", stored, err)
+	}
+	if client.evalShaCalls != 1 || client.evalCalls != 1 {
+		t.Fatalf("script calls evalsha=%d eval=%d, want 1/1", client.evalShaCalls, client.evalCalls)
+	}
+	if len(client.args) != 6 {
+		t.Fatalf("script args len=%d, want 6", len(client.args))
+	}
+	if got, want := client.args[5], int64(1500); got != want {
+		t.Fatalf("version ttl script arg=%v (%T), want %v", got, got, want)
+	}
+	if !strings.Contains(client.script, "PEXPIRE") || !strings.Contains(client.script, "PERSIST") {
+		t.Fatalf("script should refresh or persist existing version state:\n%s", client.script)
+	}
+}
+
+func TestKeyMutatorSetZeroVersionTTL(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptCmdClient{}
+	mutator, err := NewKeyMutatorWithOptions(KeyMutatorOptions{Client: client})
+	if err != nil {
+		t.Fatalf("NewKeyMutatorWithOptions: %v", err)
+	}
+	fence, err := version.NewFence()
+	if err != nil {
+		t.Fatalf("NewFence: %v", err)
+	}
+
+	stored, err := mutator.SetIfVersion(
+		context.Background(),
+		version.NewCacheKey("k"),
+		"value-key",
+		version.Snapshot{Fence: fence, Exists: true},
+		[]byte("payload"),
+		time.Minute,
+	)
+	if err != nil || !stored {
+		t.Fatalf("SetIfVersion: stored=%v err=%v", stored, err)
+	}
+	if len(client.args) != 6 {
+		t.Fatalf("script args len=%d, want 6", len(client.args))
+	}
+	if got, want := client.args[5], int64(0); got != want {
+		t.Fatalf("version ttl script arg=%v (%T), want %v", got, got, want)
 	}
 }
 
@@ -322,5 +512,117 @@ func TestVersionStoreSnapshotManyBadFence(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), key.String()) {
 		t.Fatalf("SnapshotMany error = %q, want key %q in message", err, key)
+	}
+}
+
+func TestKeyMutatorReadKeyHit(t *testing.T) {
+	t.Parallel()
+
+	fence, err := version.NewFence()
+	if err != nil {
+		t.Fatalf("NewFence: %v", err)
+	}
+	raw := []byte("wire")
+	key := version.NewCacheKey("k")
+	mutator, err := NewKeyMutator(&snapshotCmdClient{
+		mgetFn: func(_ context.Context, keys ...string) *goredis.SliceCmd {
+			if len(keys) != 2 {
+				t.Fatalf("MGet keys len=%d, want 2", len(keys))
+			}
+			if keys[1] != versionStorageKey(key) {
+				t.Fatalf("version key = %q, want %q", keys[1], versionStorageKey(key))
+			}
+			return goredis.NewSliceResult([]any{string(raw), fence.String()}, nil)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewKeyMutator: %v", err)
+	}
+
+	got, err := mutator.ReadKey(context.Background(), key, "value-key")
+	if err != nil {
+		t.Fatalf("ReadKey: %v", err)
+	}
+	if !got.Found || !bytes.Equal(got.Raw, raw) {
+		t.Fatalf("ReadKey value = found %v raw %q, want found raw %q", got.Found, got.Raw, raw)
+	}
+	if got.SnapshotErr != nil {
+		t.Fatalf("SnapshotErr = %v", got.SnapshotErr)
+	}
+	if !got.Snapshot.Exists || !got.Snapshot.Fence.Equal(fence) {
+		t.Fatalf("Snapshot = %+v, want fence %s", got.Snapshot, fence)
+	}
+}
+
+func TestKeyMutatorReadKeyBadFence(t *testing.T) {
+	t.Parallel()
+
+	key := version.NewCacheKey("k")
+	mutator, err := NewKeyMutator(&snapshotCmdClient{
+		mgetFn: func(context.Context, ...string) *goredis.SliceCmd {
+			return goredis.NewSliceResult([]any{nil, "bad-fence"}, nil)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewKeyMutator: %v", err)
+	}
+
+	got, err := mutator.ReadKey(context.Background(), key, "value-key")
+	if err != nil {
+		t.Fatalf("ReadKey: %v", err)
+	}
+	if got.Found {
+		t.Fatalf("Found = true, want false")
+	}
+	if !errors.Is(got.SnapshotErr, ErrFenceParse) {
+		t.Fatalf("SnapshotErr = %v, want ErrFenceParse", got.SnapshotErr)
+	}
+}
+
+func TestSnapshotsFromStringCmds(t *testing.T) {
+	t.Parallel()
+
+	fence, err := version.NewFence()
+	if err != nil {
+		t.Fatalf("NewFence: %v", err)
+	}
+	keys := []version.CacheKey{version.NewCacheKey("a"), version.NewCacheKey("b")}
+	cmds := []*goredis.StringCmd{
+		goredis.NewStringResult(fence.String(), nil),
+		goredis.NewStringResult("", goredis.Nil),
+	}
+
+	got, err := snapshotsFromStringCmds(keys, cmds, goredis.Nil)
+	if err != nil {
+		t.Fatalf("snapshotsFromStringCmds: %v", err)
+	}
+	if !got[keys[0]].Exists || !got[keys[0]].Fence.Equal(fence) {
+		t.Fatalf("first snapshot = %+v, want %s", got[keys[0]], fence)
+	}
+	if got[keys[1]].Exists {
+		t.Fatalf("second snapshot exists, want missing")
+	}
+
+	_, err = snapshotsFromStringCmds(
+		[]version.CacheKey{version.NewCacheKey("bad")},
+		[]*goredis.StringCmd{goredis.NewStringResult("bad-fence", nil)},
+		nil,
+	)
+	if !errors.Is(err, ErrFenceParse) {
+		t.Fatalf("bad fence error = %v, want ErrFenceParse", err)
+	}
+}
+
+func TestUsesSlotRouting(t *testing.T) {
+	t.Parallel()
+
+	if !usesSlotRouting(&goredis.ClusterClient{}) {
+		t.Fatal("ClusterClient should use slot-safe SnapshotMany path")
+	}
+	if !usesSlotRouting(&goredis.Ring{}) {
+		t.Fatal("Ring should use slot-safe SnapshotMany path")
+	}
+	if usesSlotRouting(&goredis.Client{}) {
+		t.Fatal("single Client should keep MGET SnapshotMany path")
 	}
 }

--- a/redis/store.go
+++ b/redis/store.go
@@ -22,7 +22,27 @@ type VersionStore struct {
 	closeErr    error
 }
 
-var _ version.Store = (*VersionStore)(nil)
+var (
+	_ version.Store     = (*VersionStore)(nil)
+	_ version.Refresher = (*VersionStore)(nil)
+)
+
+var refreshScript = goredis.NewScript(`
+local current = redis.call("GET", KEYS[1])
+local version_ttl_ms = tonumber(ARGV[1])
+
+if not current then
+	return 0
+end
+
+if version_ttl_ms and version_ttl_ms > 0 then
+	redis.call("PEXPIRE", KEYS[1], version_ttl_ms)
+else
+	redis.call("PERSIST", KEYS[1])
+end
+
+return 1
+`)
 
 // ErrFenceParse reports malformed authoritative fence state read from Redis.
 var ErrFenceParse = errors.New("cascache/redis: fence parse")
@@ -87,6 +107,17 @@ func (s *VersionStore) SnapshotMany(
 		return nil, err
 	}
 
+	if usesSlotRouting(rdb) {
+		return s.snapshotManyPipeline(ctx, rdb, cacheKeys)
+	}
+	return s.snapshotManyMGet(ctx, rdb, cacheKeys)
+}
+
+func (s *VersionStore) snapshotManyMGet(
+	ctx context.Context,
+	rdb goredis.UniversalClient,
+	cacheKeys []version.CacheKey,
+) (map[version.CacheKey]version.Snapshot, error) {
 	keys := make([]string, len(cacheKeys))
 	for i, k := range cacheKeys {
 		keys[i] = s.key(k)
@@ -105,6 +136,60 @@ func (s *VersionStore) SnapshotMany(
 		out[cacheKeys[i]] = snap
 	}
 	return out, nil
+}
+
+func (s *VersionStore) snapshotManyPipeline(
+	ctx context.Context,
+	rdb goredis.UniversalClient,
+	cacheKeys []version.CacheKey,
+) (map[version.CacheKey]version.Snapshot, error) {
+	cmds := make([]*goredis.StringCmd, len(cacheKeys))
+	_, err := rdb.Pipelined(ctx, func(pipe goredis.Pipeliner) error {
+		for i, k := range cacheKeys {
+			cmds[i] = pipe.Get(ctx, s.key(k))
+		}
+		return nil
+	})
+	return snapshotsFromStringCmds(cacheKeys, cmds, err)
+}
+
+func snapshotsFromStringCmds(
+	cacheKeys []version.CacheKey,
+	cmds []*goredis.StringCmd,
+	pipelineErr error,
+) (map[version.CacheKey]version.Snapshot, error) {
+	if pipelineErr != nil && !errors.Is(pipelineErr, goredis.Nil) {
+		return nil, pipelineErr
+	}
+
+	out := make(map[version.CacheKey]version.Snapshot, len(cacheKeys))
+	for i, cmd := range cmds {
+		if cmd == nil {
+			return nil, fmt.Errorf("cascache/redis: missing pipeline command for %s", cacheKeys[i])
+		}
+		if err := cmd.Err(); errors.Is(err, goredis.Nil) {
+			out[cacheKeys[i]] = version.Snapshot{}
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+
+		snap, err := parseSnapshotFence(cacheKeys[i], cmd.Val())
+		if err != nil {
+			return nil, err
+		}
+		out[cacheKeys[i]] = snap
+	}
+	return out, nil
+}
+
+func usesSlotRouting(rdb goredis.UniversalClient) bool {
+	switch rdb.(type) {
+	case *goredis.ClusterClient, *goredis.Ring:
+		return true
+	default:
+		return false
+	}
 }
 
 // CreateIfMissing creates authoritative state with a fresh fence only if absent.
@@ -153,6 +238,26 @@ func (s *VersionStore) Advance(ctx context.Context, cacheKey version.CacheKey) (
 		return version.Snapshot{}, err
 	}
 	return version.Snapshot{Fence: f, Exists: true}, nil
+}
+
+// Refresh extends or removes expiry for existing authoritative version state
+// without changing its fence.
+func (s *VersionStore) Refresh(ctx context.Context, cacheKey version.CacheKey) (bool, error) {
+	rdb, err := s.client()
+	if err != nil {
+		return false, err
+	}
+
+	r, err := refreshScript.Run(
+		ctx,
+		rdb,
+		[]string{s.key(cacheKey)},
+		ttlMillis(s.versionTTL),
+	).Int()
+	if err != nil {
+		return false, err
+	}
+	return r == 1, nil
 }
 
 // Cleanup is not applicable for Redis by default.

--- a/single.go
+++ b/single.go
@@ -1,0 +1,371 @@
+package cascache
+
+import (
+	"context"
+	"time"
+
+	"github.com/unkn0wn-root/cascache/v3/internal/keys"
+	"github.com/unkn0wn-root/cascache/v3/internal/wire"
+	"github.com/unkn0wn-root/cascache/v3/version"
+)
+
+type singleWrite struct {
+	storageKey string
+	wire       []byte
+	cost       int64
+}
+
+// Get looks up a single key and returns its value only if the cached entry is
+// still usable.
+//
+// The read passes through three validation gates:
+//  1. Wire: the raw bytes must parse as a valid single-entry frame.
+//  2. Version: the embedded fence must match the current
+//     authoritative fence in the version store.
+//  3. Codec: the payload must decode with the configured codec.
+//
+// Failures in (1), (2), and (3) delete the provider entry and return a miss.
+// If the current authoritative fence cannot be loaded, Get returns a miss without
+// serving or deleting the cached value. Provider read failures are returned
+// as *OpError with OpGet.
+func (c *cache[V]) Get(ctx context.Context, key string) (V, bool, error) {
+	var zero V
+	if !c.enabled {
+		return zero, false, nil
+	}
+
+	sk := c.singleKeys(key)
+	storageKey := sk.Value.String()
+	ckey := toVersionCacheKey(sk.Cache)
+
+	if c.keyReader != nil {
+		kr, err := c.keyReader.ReadKey(ctx, ckey, storageKey)
+		if err != nil {
+			return zero, false, opError(OpGet, key, err)
+		}
+		if !kr.Found {
+			return zero, false, nil
+		}
+		return c.serveSingleRaw(ctx, key, storageKey, kr.Raw, kr.Snapshot, kr.SnapshotErr)
+	}
+
+	raw, ok, err := c.provider.Get(ctx, storageKey)
+	if err != nil {
+		return zero, false, opError(OpGet, key, err)
+	}
+	if !ok {
+		return zero, false, nil
+	}
+
+	return c.serveSingleRawWithSnapshotLoad(ctx, key, storageKey, raw, ckey)
+}
+
+// SnapshotVersion returns the current version for one logical key.
+func (c *cache[V]) SnapshotVersion(ctx context.Context, key string) (Version, error) {
+	snap, err := c.loadSnapshot(ctx, c.versionKey(key))
+	if err != nil {
+		return Version{}, opError(OpSnapshot, key, err)
+	}
+	return versionFromSnapshot(snap), nil
+}
+
+// SetIfVersion writes a value only when the current version still matches the
+// caller's observed version using the cache's configured default TTL.
+func (c *cache[V]) SetIfVersion(
+	ctx context.Context,
+	key string,
+	value V,
+	version Version,
+) (WriteResult, error) {
+	return c.SetIfVersionWithTTL(ctx, key, value, version, c.defaultTTL)
+}
+
+// SetIfVersionWithTTL writes a value only when the current version still
+// matches the caller's observed version. Generic backends perform a final
+// version read immediately before the provider write. When KeyWriter is
+// configured, the backend-native implementation collapses compare and write
+// into one operation.
+func (c *cache[V]) SetIfVersionWithTTL(
+	ctx context.Context,
+	key string,
+	value V,
+	version Version,
+	ttl time.Duration,
+) (WriteResult, error) {
+	if !c.enabled {
+		return WriteResult{Outcome: WriteOutcomeDisabled}, nil
+	}
+	if ttl == 0 {
+		ttl = c.defaultTTL
+	}
+
+	payload, err := c.codec.Encode(value)
+	if err != nil {
+		return WriteResult{}, opError(OpSet, key, err)
+	}
+
+	sk := c.singleKeys(key)
+	ckey := toVersionCacheKey(sk.Cache)
+
+	if c.keyWriter != nil {
+		s, kerr := c.keyWriter.SetIfVersion(
+			ctx,
+			ckey,
+			sk.Value.String(),
+			version.snapshot(),
+			payload,
+			ttl,
+		)
+		if kerr != nil {
+			return WriteResult{}, opError(OpSet, key, kerr)
+		}
+		if !s {
+			return WriteResult{Outcome: WriteOutcomeVersionMismatch}, nil
+		}
+		return WriteResult{Outcome: WriteOutcomeStored}, nil
+	}
+
+	snap, ok, err := c.checkSnapshot(ctx, ckey, version)
+	if err != nil {
+		return WriteResult{Outcome: WriteOutcomeSnapshotError}, opError(OpSnapshot, key, err)
+	}
+	if !ok {
+		return WriteResult{Outcome: WriteOutcomeVersionMismatch}, nil
+	}
+	if !version.IsMissing() {
+		var refreshed bool
+		refreshed, err = c.refreshVersion(ctx, ckey)
+		if err != nil {
+			return WriteResult{Outcome: WriteOutcomeSnapshotError}, opError(OpSnapshot, key, err)
+		}
+		if !refreshed {
+			return WriteResult{Outcome: WriteOutcomeVersionMismatch}, nil
+		}
+	}
+
+	sw, err := c.buildSingleWrite(sk, snap.Fence, payload)
+	if err != nil {
+		return WriteResult{}, opError(OpSet, key, err)
+	}
+
+	s, err := c.setSingle(ctx, sw, ttl)
+	if err != nil {
+		return WriteResult{}, opError(OpSet, key, err)
+	}
+	if !s {
+		return WriteResult{Outcome: WriteOutcomeProviderRejected}, nil
+	}
+	return WriteResult{Outcome: WriteOutcomeStored}, nil
+}
+
+// Invalidate marks a key as stale so that future readers will not serve it.
+// Backends perform two operations in a specific order:
+//
+//  1. Advance the authoritative fence in the version store, which makes every
+//     existing cached entry for this key stale because its embedded fence
+//     will no longer match.
+//
+//  2. Delete the single entry from the provider as a courtesy so the stale
+//     bytes do not linger and waste memory.
+//
+// The order matters. Advancing first ensures that even if the delete fails,
+// readers will see the fence mismatch and self-heal on the next read.
+// If we deleted first and the advance then failed, a batch entry could reseed
+// the single with stale data and the fence check would still pass.
+func (c *cache[V]) Invalidate(ctx context.Context, key string) error {
+	if !c.enabled {
+		return nil
+	}
+
+	sk := c.singleKeys(key)
+	if c.keyInvalidator != nil {
+		if err := c.keyInvalidator.Invalidate(
+			ctx,
+			toVersionCacheKey(sk.Cache),
+			sk.Value.String(),
+		); err != nil {
+			c.hooks.InvalidateOutage(key, err, nil)
+			return &InvalidateError{
+				Key:        key,
+				AdvanceErr: opError(OpInvalidate, key, err),
+			}
+		}
+		return nil
+	}
+
+	_, bErr := c.advanceVersion(ctx, toVersionCacheKey(sk.Cache))
+	delErr := c.provider.Del(ctx, sk.Value.String())
+
+	if bErr != nil {
+		c.hooks.InvalidateOutage(key, bErr, delErr)
+		return &InvalidateError{
+			Key:        key,
+			AdvanceErr: opError(OpInvalidate, key, bErr),
+			DelErr:     opError(OpInvalidate, key, delErr),
+		}
+	}
+	return nil
+}
+
+func (c *cache[V]) serveSingleRaw(
+	ctx context.Context,
+	key string,
+	storageKey string,
+	raw []byte,
+	snap version.Snapshot,
+	snapErr error,
+) (V, bool, error) {
+	var zero V
+
+	dfence, payload, ok := c.decodeSingleRaw(ctx, storageKey, raw)
+	if !ok {
+		return zero, false, nil
+	}
+
+	if snapErr != nil {
+		c.hooks.VersionSnapshotError(1, snapErr)
+		return zero, false, nil
+	}
+	return c.serveSingleDecoded(ctx, key, storageKey, dfence, payload, snap)
+}
+
+func (c *cache[V]) serveSingleRawWithSnapshotLoad(
+	ctx context.Context,
+	key string,
+	storageKey string,
+	raw []byte,
+	ckey version.CacheKey,
+) (V, bool, error) {
+	var zero V
+
+	dfence, payload, ok := c.decodeSingleRaw(ctx, storageKey, raw)
+	if !ok {
+		return zero, false, nil
+	}
+
+	snap, err := c.loadSnapshot(ctx, ckey)
+	if err != nil {
+		return zero, false, nil
+	}
+	return c.serveSingleDecoded(ctx, key, storageKey, dfence, payload, snap)
+}
+
+func (c *cache[V]) decodeSingleRaw(
+	ctx context.Context,
+	storageKey string,
+	raw []byte,
+) (version.Fence, []byte, bool) {
+	dfence, payload, err := wire.DecodeSingle(raw)
+	if err != nil {
+		c.selfHealSingle(ctx, storageKey, SelfHealReasonCorrupt)
+		return version.Fence{}, nil, false
+	}
+	return dfence, payload, true
+}
+
+func (c *cache[V]) serveSingleDecoded(
+	ctx context.Context,
+	key string,
+	storageKey string,
+	dfence version.Fence,
+	payload []byte,
+	snap version.Snapshot,
+) (V, bool, error) {
+	var zero V
+
+	if !snap.Exists {
+		c.selfHealSingle(ctx, storageKey, SelfHealReasonVersionMissing)
+		return zero, false, nil
+	}
+	if !dfence.Equal(snap.Fence) {
+		c.selfHealSingle(ctx, storageKey, SelfHealReasonVersionMismatch)
+		return zero, false, nil
+	}
+
+	v, err := c.codec.Decode(payload)
+	if err != nil {
+		c.selfHealSingle(ctx, storageKey, SelfHealReasonValueDecode)
+		return zero, false, nil
+	}
+	if guardReason := c.guardSingleRead(ctx, key, v); guardReason != "" {
+		c.selfHealSingle(ctx, storageKey, guardReason)
+		return zero, false, nil
+	}
+	return v, true, nil
+}
+
+// selfHealSingle deletes one unusable single entry and emits the matching
+// hook reason. Read paths call this after conservative validation failures.
+func (c *cache[V]) selfHealSingle(ctx context.Context, storageKey string, reason SelfHealReason) {
+	_ = c.provider.Del(ctx, storageKey)
+	c.hooks.SelfHealSingle(storageKey, reason)
+}
+
+// buildSingleWrite builds the provider payload and admission metadata for a
+// single entry write from an already encoded value payload.
+func (c *cache[V]) buildSingleWrite(
+	sk keys.Single,
+	fence version.Fence,
+	payload []byte,
+) (singleWrite, error) {
+	wireb, err := wire.EncodeSingle(fence, payload)
+	if err != nil {
+		return singleWrite{}, err
+	}
+
+	sKey := sk.Value.String()
+	return singleWrite{
+		storageKey: sKey,
+		wire:       wireb,
+		cost:       c.computeSetCost(sKey, wireb, false, 1),
+	}, nil
+}
+
+// setSingle executes a prepared single-entry provider Set and reports
+// admission rejection through hooks without treating it as an error.
+func (c *cache[V]) setSingle(ctx context.Context, sw singleWrite, ttl time.Duration) (bool, error) {
+	ok, err := c.provider.Set(ctx, sw.storageKey, sw.wire, sw.cost, ttl)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		c.hooks.ProviderSetRejected(sw.storageKey, false)
+	}
+	return ok, nil
+}
+
+// writeSingle encodes one single entry frame from an already validated batch
+// member and stores it through the normal provider Set path.
+func (c *cache[V]) writeSingle(
+	ctx context.Context,
+	key string,
+	fence version.Fence,
+	payload []byte,
+	ttl time.Duration,
+) error {
+	sk := c.singleKeys(key)
+	sw, err := c.buildSingleWrite(sk, fence, payload)
+	if err != nil {
+		return err
+	}
+	_, err = c.setSingle(ctx, sw, ttl)
+	return err
+}
+
+// addSingle encodes one single-entry frame from an already validated batch
+// member and inserts it only if the provider reports the key as missing.
+func (c *cache[V]) addSingle(
+	ctx context.Context,
+	key string,
+	fence version.Fence,
+	payload []byte,
+	ttl time.Duration,
+) error {
+	sk := c.singleKeys(key)
+	sw, err := c.buildSingleWrite(sk, fence, payload)
+	if err != nil {
+		return err
+	}
+	_, err = c.adder.Add(ctx, sw.storageKey, sw.wire, sw.cost, ttl)
+	return err
+}

--- a/version/store.go
+++ b/version/store.go
@@ -44,3 +44,11 @@ type Store interface {
 	// Close releases resources (no-op ok).
 	Close(context.Context) error
 }
+
+// Refresher is an optional Store capability for backends with expiring
+// authoritative metadata. Refresh extends or removes expiry for existing
+// version state without changing its fence. refreshed=false means no current
+// state existed to refresh.
+type Refresher interface {
+	Refresh(ctx context.Context, cacheKey CacheKey) (refreshed bool, err error)
+}


### PR DESCRIPTION
- add optional `KeyReader` / `KeyReadResult` API for backends that can read a cached value and authoritative version state together.
- wire `redis.New` to use the Redis `KeyReader` path, so single-key `Get` can fetch value + fence in one Redis call.
- refresh Redis version metadata on successful writes against existing versions so active keys do not lose uthoritative version state while the cached value is still valid.
- make Redis `SnapshotMany` safer for Cluster/Ring clients by using pipelined `GET`.
- return both version store and provider close errors from `Close`.
- move single-key cache logic into `single.go`
- update README numbers from the latest local Redis benchmarks.